### PR TITLE
Add Vitest testing setup and initial UI tests

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,3 +10,17 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Running tests
+
+Install dependencies if you have not already:
+
+```bash
+npm install
+```
+
+Execute the unit test suite with coverage reporting:
+
+```bash
+npm test
+```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react-swc": "^3.9.0",
@@ -24,7 +26,9 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
-        "vite": "^6.3.5"
+        "msw": "^2.6.9",
+        "vite": "^6.3.5",
+        "vitest": "^2.1.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "axios": "^1.9.0",
@@ -22,11 +23,15 @@
     "@eslint/js": "^9.25.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "msw": "^2.6.9",
+    "vite": "^6.3.5",
+    "vitest": "^2.1.6"
   }
 }

--- a/frontend/src/components/AdminPanel/__tests__/AdminStats.test.jsx
+++ b/frontend/src/components/AdminPanel/__tests__/AdminStats.test.jsx
@@ -1,0 +1,80 @@
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import AdminStats from '../AdminStats.jsx';
+import axiosInstance from '../../../api/axiosInstance';
+
+vi.mock('../../../api/axiosInstance', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe('AdminStats', () => {
+  beforeEach(() => {
+    axiosInstance.get.mockReset();
+  });
+
+  it('shows loading spinner while statistics are being fetched', () => {
+    axiosInstance.get.mockResolvedValue({ data: {} });
+
+    render(<AdminStats />);
+
+    expect(screen.getByText('טוען סטטיסטיקות...')).toBeInTheDocument();
+  });
+
+  it('renders statistics cards and recent activity data', async () => {
+    const statsResponse = {
+      monthlyNewUsers: 2500,
+      weeklyNewUsers: 120,
+      monthlyNewBusinesses: 75,
+      weeklyNewBusinesses: 8,
+      pendingReviewDeletions: 3,
+      pendingApprovals: 6,
+      systemStatus: 'operational',
+    };
+
+    const activityResponse = [
+      {
+        id: 1,
+        type: 'user_registration',
+        message: 'משתמש חדש נרשם',
+        timestamp: '2024-04-10T10:00:00Z',
+      },
+    ];
+
+    axiosInstance.get
+      .mockResolvedValueOnce({ data: statsResponse })
+      .mockResolvedValueOnce({ data: activityResponse });
+
+    render(<AdminStats />);
+
+    await waitFor(() => {
+      expect(screen.getByText('סטטיסטיקות המערכת')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('משתמשים חדשים החודש')).toBeInTheDocument();
+    expect(screen.getByText(/2,500/)).toBeInTheDocument();
+    expect(screen.getByText('משתמש חדש נרשם')).toBeInTheDocument();
+  });
+
+  it('handles empty activity list gracefully', async () => {
+    const statsResponse = {
+      monthlyNewUsers: 0,
+      weeklyNewUsers: 0,
+      monthlyNewBusinesses: 0,
+      weeklyNewBusinesses: 0,
+      pendingReviewDeletions: 0,
+      pendingApprovals: 0,
+      systemStatus: 'degraded',
+    };
+
+    axiosInstance.get
+      .mockResolvedValueOnce({ data: statsResponse })
+      .mockResolvedValueOnce({ data: [] });
+
+    render(<AdminStats />);
+
+    expect(await screen.findByText('אין פעילות אחרונה')).toBeInTheDocument();
+    expect(screen.getByText('⏳')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/UserDashboard/__tests__/UserDashboard.test.jsx
+++ b/frontend/src/components/UserDashboard/__tests__/UserDashboard.test.jsx
@@ -1,0 +1,99 @@
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import UserDashboard from '../UserDashboard.jsx';
+import axiosInstance from '../../../api/axiosInstance';
+
+vi.mock('../../../api/axiosInstance', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../ProfileModal/ProfileModal', () => ({
+  default: ({ isOpen }) => (isOpen ? <div data-testid="profile-modal" /> : null),
+}));
+
+vi.mock('../ReviewableAppointments/ReviewableAppointments', () => ({
+  default: () => <div data-testid="reviewable-appointments" />,
+}));
+
+describe('UserDashboard', () => {
+  const mockUser = { id: 1 };
+
+  beforeEach(() => {
+    axiosInstance.get.mockReset();
+  });
+
+  it('renders loading state while data is being fetched', () => {
+    axiosInstance.get.mockResolvedValueOnce({ data: null });
+
+    render(<UserDashboard user={mockUser} />);
+
+    expect(screen.getByText('טוען נתונים...')).toBeInTheDocument();
+  });
+
+  it('displays user dashboard data when API responds successfully', async () => {
+    const dashboardResponse = {
+      user: { firstName: 'דניאל' },
+      upcomingAppointments: [
+        {
+          id: 1,
+          date: '2024-04-10T10:00:00Z',
+          businessName: 'Salon One',
+          serviceName: 'Haircut',
+          price: 120,
+          status: 'confirmed',
+        },
+      ],
+      pastAppointments: [],
+      favorites: [
+        { id: 3, name: 'Spa Life', category: 'Spa', address: 'Main St 5', visitCount: 2 },
+      ],
+      favoriteBusinesses: 1,
+    };
+
+    axiosInstance.get.mockResolvedValueOnce({ data: dashboardResponse });
+
+    render(<UserDashboard user={mockUser} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('שלום, דניאל')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Salon One')).toBeInTheDocument();
+    expect(screen.getByText('Haircut')).toBeInTheDocument();
+    expect(screen.getByText('₪120')).toBeInTheDocument();
+    expect(screen.getByText('העסקים המועדפים שלי')).toBeInTheDocument();
+  });
+
+  it('shows empty state when dashboard returns no appointments', async () => {
+    const dashboardResponse = {
+      user: { firstName: 'יעל' },
+      upcomingAppointments: [],
+      pastAppointments: [],
+      favorites: [],
+      favoriteBusinesses: 0,
+    };
+
+    axiosInstance.get.mockResolvedValueOnce({ data: dashboardResponse });
+
+    render(<UserDashboard user={mockUser} />);
+
+    const viewAllButton = await screen.findByRole('button', {
+      name: 'הצג את כל התורים (0)',
+    });
+
+    fireEvent.click(viewAllButton);
+
+    expect(await screen.findByText('אין תורים')).toBeInTheDocument();
+    expect(screen.getByText('עדיין לא קבעת תורים במערכת')).toBeInTheDocument();
+  });
+
+  it('shows message when API returns empty payload', async () => {
+    axiosInstance.get.mockResolvedValueOnce({ data: null });
+
+    render(<UserDashboard user={mockUser} />);
+
+    expect(await screen.findByText('לא נמצאו נתונים')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js',
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest configuration with Testing Library and jest-dom setup for the frontend
- create initial tests for the UserDashboard and AdminStats components covering loading, data, and empty states
- document the `npm test` command in the frontend README

## Testing
- not run (dependency installation failed in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68f16b943b88832d9576e6fe75e10c2d