### PR TITLE
Update appointment creation default status to pending

### DIFF
--- a/backend/controllers/appointmentController.js
+++ b/backend/controllers/appointmentController.js
@@ -84,7 +84,7 @@ const createAppointment = async (req, res) => {
         status,
         notes,
         created_at
-      ) VALUES (?, ?, ?, ?, 'scheduled', ?, NOW())
+      ) VALUES (?, ?, ?, ?, 'pending', ?, NOW())
     `;
 
     const [result] = await connection.query(query, [
@@ -108,7 +108,7 @@ const createAppointment = async (req, res) => {
         serviceName,
         servicePrice,
         serviceDuration,
-        status: 'scheduled'
+        status: 'pending'
       }
     });
 

--- a/backend/tests/appointments.test.js
+++ b/backend/tests/appointments.test.js
@@ -55,7 +55,7 @@ describe('Appointment Controller', () => {
 
       // Mock existing customer lookup
       mockDb.query
-        .mockResolvedValueOnce([{ user_id: 123 }]) // Customer exists
+        .mockResolvedValueOnce([[{ user_id: 123 }]]) // Customer exists
         .mockResolvedValueOnce([{ insertId: 456 }]); // Appointment created
 
       await appointmentController.createAppointment(req, res);
@@ -72,12 +72,16 @@ describe('Appointment Controller', () => {
         expect.stringContaining('INSERT INTO appointments'),
         expect.arrayContaining([123, 1, 1, '2025-09-10 10:00:00'])
       );
+      expect(mockDb.query.mock.calls[1][0]).toContain("'pending'");
 
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Appointment created successfully',
-        appointmentId: 456
-      });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Appointment created successfully',
+          appointmentId: 456,
+          appointment: expect.objectContaining({ status: 'pending' })
+        })
+      );
     });
 
     test('should create appointment with new customer', async () => {
@@ -85,7 +89,7 @@ describe('Appointment Controller', () => {
 
       // Mock no existing customer, then customer creation, then appointment creation
       mockDb.query
-        .mockResolvedValueOnce([]) // No existing customer
+        .mockResolvedValueOnce([[]]) // No existing customer
         .mockResolvedValueOnce([{ insertId: 789 }]) // New customer created
         .mockResolvedValueOnce([{ insertId: 456 }]); // Appointment created
 
@@ -104,8 +108,16 @@ describe('Appointment Controller', () => {
         expect.stringContaining('INSERT INTO appointments'),
         expect.arrayContaining([789, 1, 1, '2025-09-10 10:00:00'])
       );
+      expect(mockDb.query.mock.calls[2][0]).toContain("'pending'");
 
       expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Appointment created successfully',
+          appointmentId: 456,
+          appointment: expect.objectContaining({ status: 'pending' })
+        })
+      );
     });
 
     test('should handle missing required fields', async () => {
@@ -166,7 +178,7 @@ describe('Appointment Controller', () => {
 
       // Mock no existing customer, then error during customer creation
       mockDb.query
-        .mockResolvedValueOnce([]) // No existing customer
+        .mockResolvedValueOnce([[]]) // No existing customer
         .mockRejectedValueOnce(new Error('Customer creation failed'));
 
       await appointmentController.createAppointment(req, res);
@@ -184,7 +196,7 @@ describe('Appointment Controller', () => {
 
       // Mock existing customer, then error during appointment creation
       mockDb.query
-        .mockResolvedValueOnce([{ user_id: 123 }]) // Customer exists
+        .mockResolvedValueOnce([[{ user_id: 123 }]]) // Customer exists
         .mockRejectedValueOnce(new Error('Appointment creation failed'));
 
       await appointmentController.createAppointment(req, res);
@@ -205,7 +217,7 @@ describe('Appointment Controller', () => {
       };
 
       mockDb.query
-        .mockResolvedValueOnce([{ user_id: 123 }]) // Customer exists
+        .mockResolvedValueOnce([[{ user_id: 123 }]]) // Customer exists
         .mockResolvedValueOnce([{ insertId: 456 }]); // Appointment created
 
       await appointmentController.createAppointment(req, res);
@@ -230,7 +242,7 @@ describe('Appointment Controller', () => {
       };
 
       mockDb.query
-        .mockResolvedValueOnce([]) // No existing customer
+        .mockResolvedValueOnce([[]]) // No existing customer
         .mockResolvedValueOnce([{ insertId: 789 }]) // New customer created
         .mockResolvedValueOnce([{ insertId: 456 }]); // Appointment created
 

--- a/backend/tests/reportService.test.js
+++ b/backend/tests/reportService.test.js
@@ -77,7 +77,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]]) // Business info
         .mockResolvedValueOnce([mockAppointments]) // Appointments
-        .mockResolvedValueOnce([{ count: 1 }]); // New customers (mocked)
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]); // New customers (mocked)
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -105,7 +105,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([mockAppointments])
-        .mockResolvedValueOnce([{ count: 1 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -119,7 +119,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([mockAppointments])
-        .mockResolvedValueOnce([{ count: 1 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -141,7 +141,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([[]]) // No appointments
-        .mockResolvedValueOnce([{ count: 0 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 0 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -173,7 +173,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([appointmentsWithMissingService])
-        .mockResolvedValueOnce([{ count: 1 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -194,7 +194,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([appointmentsWithNullPrice])
-        .mockResolvedValueOnce([{ count: 1 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -206,7 +206,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([[]])
-        .mockResolvedValueOnce([{ count: 0 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 0 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -228,7 +228,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([[]])
-        .mockResolvedValueOnce([{ count: 5 }]); // New customers count
+        .mockResolvedValueOnce([[{ new_customers_count: 5 }]]); // New customers count
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -292,7 +292,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([appointmentsWithDifferentStatuses])
-        .mockResolvedValueOnce([{ count: 1 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -318,7 +318,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([mixedStatusAppointments])
-        .mockResolvedValueOnce([{ count: 1 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]);
 
       const result = await reportService.generateDailyReport(1, '2025-09-10');
 
@@ -353,7 +353,7 @@ describe('Report Service', () => {
       mockDb.query
         .mockResolvedValueOnce([[mockBusiness]])
         .mockResolvedValueOnce([appointmentWithBadDate])
-        .mockResolvedValueOnce([{ count: 1 }]);
+        .mockResolvedValueOnce([[{ new_customers_count: 1 }]]);
 
       // Should not throw error, but hour might be NaN
       const result = await reportService.generateDailyReport(1, '2025-09-10');


### PR DESCRIPTION
## Summary
- change the appointment creation flow to use `pending` as the default status and return it to callers
- extend the appointment controller unit tests to assert the new status value and the SQL payload
- adjust report service mocks to reflect the MySQL promise API shape so status checks remain valid

## Testing
- npm test *(fails: existing dbSingleton suite requires additional mock setup that was not part of this change)*
- npm test -- tests/appointments.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f16d3c4654832da0823beb99c89be2